### PR TITLE
Fix renderdoc 3rd-party for Linux and update to renderdoc 1.29

### DIFF
--- a/scripts/misc/update-3rdp.run
+++ b/scripts/misc/update-3rdp.run
@@ -461,8 +461,17 @@ local PACKAGES =
 	{
 		type = "GET",
 		name = "renderdoc",
+		os = "linux",
+		url = "https://renderdoc.org/stable/1.29/renderdoc_1.29.tar.gz",
+		patch = function()
+			run:execute(TAR .. " -xf renderdoc_1.29.tar.gz")
+		end
+	},
+	{
+		type = "GET",
+		name = "renderdoc",
 		os = "windows",
-		url = "https://renderdoc.org/stable/1.26/RenderDoc_1.26_64.zip",
+		url = "https://renderdoc.org/stable/1.29/RenderDoc_1.29_64.zip",
 		patch = function()
 			run:execute(UNZIP .. " -qq RenderDoc_1.26_64.zip")
 		end

--- a/scripts/misc/update-3rdp.run
+++ b/scripts/misc/update-3rdp.run
@@ -471,7 +471,7 @@ local PACKAGES =
 		type = "GET",
 		name = "renderdoc",
 		os = "windows",
-		url = "https://renderdoc.org/stable/1.29/RenderDoc_1.29_64.zip",
+		url = "https://renderdoc.org/stable/1.26/RenderDoc_1.26_64.zip",
 		patch = function()
 			run:execute(UNZIP .. " -qq RenderDoc_1.26_64.zip")
 		end


### PR DESCRIPTION
Looks like it was missing renderdoc 3rd party for linux, so adding that as well as updating to renderdoc 1.29 on both Windows and Linux