### PR TITLE
Cleaned up unnecessary files from mimalloc

### DIFF
--- a/resources/build/ExternLinux.xms
+++ b/resources/build/ExternLinux.xms
@@ -5579,16 +5579,6 @@
 							<excludeFilter/>
 							<items/>
 						</item>
-						<item type="Filter">
-							<name>unix</name>
-							<items>
-								<item type="File" version="1">
-									<fileName>prim/unix/*.c</fileName>
-									<excludeFilter/>
-									<items/>
-								</item>
-							</items>
-						</item>
 					</items>
 				</item>
 			</items>

--- a/resources/build/ExternLinux.xms
+++ b/resources/build/ExternLinux.xms
@@ -270,7 +270,7 @@
 			<items>
 				<item type="File" version="1">
 					<fileName>src/*.cpp</fileName>
-					<excludeFilter/>
+					<excludeFilter>btBulletCollisionAll.cpp;btBulletDynamicsAll.cpp;btLinearMathAll.cpp</excludeFilter>
 					<items/>
 				</item>
 				<item type="File" version="1">

--- a/resources/build/ExternWin64.xms
+++ b/resources/build/ExternWin64.xms
@@ -279,7 +279,7 @@
 			<items>
 				<item type="File" version="1">
 					<fileName>src/*.cpp</fileName>
-					<excludeFilter/>
+					<excludeFilter>btBulletCollisionAll.cpp;btBulletDynamicsAll.cpp;btLinearMathAll.cpp</excludeFilter>
 					<items/>
 				</item>
 				<item type="File" version="1">

--- a/resources/build/ExternWin64.xms
+++ b/resources/build/ExternWin64.xms
@@ -6593,7 +6593,7 @@
 			<items>
 				<item type="File" version="1">
 					<fileName>*.*</fileName>
-					<excludeFilter>arena-abandon.c;alloc-override.c;page-queue.c;free.c</excludeFilter>
+					<excludeFilter>arena-abandon.c;alloc-override.c;page-queue.c;static.c;free.c</excludeFilter>
 					<items/>
 				</item>
 				<item type="Filter">
@@ -6603,16 +6603,6 @@
 							<fileName>prim/*.c</fileName>
 							<excludeFilter/>
 							<items/>
-						</item>
-						<item type="Filter">
-							<name>windows</name>
-							<items>
-								<item type="File" version="1">
-									<fileName>prim/windows/*.c</fileName>
-									<excludeFilter/>
-									<items/>
-								</item>
-							</items>
 						</item>
 					</items>
 				</item>


### PR DESCRIPTION
prim.c will include the appropriate platform specific prim file.

This also cleans up some warnings in the windows version, static.c is not necessary