### PR TITLE
Plugin cleanup + Misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@
 /build
 /bin/latest
 /bin/git
+/bin/win64/.wget-hsts
 /data/Temp
 /data/Output
 /.vs
 /resources/documentation/html
 /resources/documentation/latest
 /resources/documentation/latex
+/jconfig.h

--- a/code/Editor/App/EditorForm.cpp
+++ b/code/Editor/App/EditorForm.cpp
@@ -846,10 +846,13 @@ void EditorForm::destroy()
 {
 	closeWorkspace();
 
-	// Destroy all plugins.
-	for (auto editorPluginSite : m_editorPluginSites)
+	// Destroy all plugins (in reverse order).
+	while (!m_editorPluginSites.empty())
+	{
+		auto editorPluginSite = m_editorPluginSites.back();
 		editorPluginSite->destroy();
-	m_editorPluginSites.clear();
+		m_editorPluginSites.pop_back();
+	}
 
 	// Destroy shortcut table.
 	safeDestroy(m_shortcutTable);

--- a/code/Runtime/Impl/Application.cpp
+++ b/code/Runtime/Impl/Application.cpp
@@ -413,10 +413,13 @@ void Application::destroy()
 	if (m_scriptServer)
 		m_scriptServer->cleanup(true);
 
-	// Shutdown plugins.
-	for (auto plugin : m_plugins)
+	// Shutdown plugins (in reverse order).
+	while (!m_plugins.empty())
+	{
+		auto plugin = m_plugins.back();
 		plugin->destroy(m_environment);
-	m_plugins.clear();
+		m_plugins.pop_back();
+	}
 
 	// Destroy environment servers.
 	safeDestroy(m_resourceServer);

--- a/code/Spark/Editor/EditorPage.cpp
+++ b/code/Spark/Editor/EditorPage.cpp
@@ -119,6 +119,7 @@ bool EditorPage::create(ui::Container* parent)
 void EditorPage::destroy()
 {
 	safeDestroy(m_previewControl);
+	safeDestroy(m_resourceManager);
 }
 
 bool EditorPage::dropInstance(db::Instance* instance, const ui::Point& position)


### PR DESCRIPTION
1. Ensure editor and runtime plugins are destroyed in reverse order.
2. Destroy resource manager when Spark EditorPage is destroyed.
3. Ignore some generated files (I've accidentally added them to source control a few time -- git add .).