### PR TITLE
Allow setting scissor rectangle on RenderView

### DIFF
--- a/code/Render/Context/RenderBlock.cpp
+++ b/code/Render/Context/RenderBlock.cpp
@@ -220,6 +220,13 @@ void SetViewportRenderBlock::render(IRenderView* renderView) const
 	T_CONTEXT_POP_MARKER(renderView);
 }
 
+void SetScissorRenderBlock::render(IRenderView* renderView) const
+{
+	T_CONTEXT_PUSH_MARKER(renderView, name);
+	renderView->setScissor(scissor);
+	T_CONTEXT_POP_MARKER(renderView);
+}
+
 void BarrierRenderBlock::render(IRenderView* renderView) const
 {
 	T_CONTEXT_PUSH_MARKER(renderView, name);

--- a/code/Render/Context/RenderBlock.h
+++ b/code/Render/Context/RenderBlock.h
@@ -244,6 +244,16 @@ public:
 	virtual void render(IRenderView* renderView) const override final;
 };
 
+/*! Set target scissor block.
+ * \ingroup Render
+ */
+class T_DLLCLASS SetScissorRenderBlock : public RenderBlock
+{
+public:
+	Rectangle scissor;
+	virtual void render(IRenderView* renderView) const override final;
+};
+
 /*! Barrier block.
  * \ingroup Render
  */

--- a/code/Render/Context/RenderBlock.h
+++ b/code/Render/Context/RenderBlock.h
@@ -251,6 +251,7 @@ class T_DLLCLASS SetScissorRenderBlock : public RenderBlock
 {
 public:
 	Rectangle scissor;
+
 	virtual void render(IRenderView* renderView) const override final;
 };
 

--- a/code/Render/IRenderView.h
+++ b/code/Render/IRenderView.h
@@ -94,6 +94,8 @@ public:
 	virtual bool setGamma(float gamma) = 0;
 
 	virtual void setViewport(const Viewport& viewport) = 0;
+    
+	virtual void setScissor(const Rectangle& scissor) = 0;
 
 	virtual SystemWindow getSystemWindow() = 0;
 

--- a/code/Render/Types.h
+++ b/code/Render/Types.h
@@ -428,6 +428,36 @@ struct Viewport
 	}
 };
 
+/*! Render scissor rectangle. */
+struct Rectangle
+{
+	int32_t left = 0;
+	int32_t top = 0;
+	int32_t width = 0;
+	int32_t height = 0;
+	Rectangle() = default;
+	Rectangle(int32_t l, int32_t t, int32_t w, int32_t h)
+		: left(l)
+		, top(t)
+		, width(w)
+		, height(h)
+	{
+	}
+
+	bool operator==(const Rectangle& other) const
+	{
+		return left == other.left &&
+			top == other.top &&
+			width == other.width &&
+			height == other.height;
+	}
+
+	bool operator!=(const Rectangle& other) const
+	{
+		return !(*this == other);
+	}
+};
+
 /*! Display mode structure. */
 struct DisplayMode
 {

--- a/code/Render/Types.h
+++ b/code/Render/Types.h
@@ -435,27 +435,20 @@ struct Rectangle
 	int32_t top = 0;
 	int32_t width = 0;
 	int32_t height = 0;
+
 	Rectangle() = default;
+
 	Rectangle(int32_t l, int32_t t, int32_t w, int32_t h)
-		: left(l)
-		, top(t)
-		, width(w)
-		, height(h)
+	: left(l)
+	, top(t)
+	, width(w)
+	, height(h)
 	{
 	}
 
-	bool operator==(const Rectangle& other) const
-	{
-		return left == other.left &&
-			top == other.top &&
-			width == other.width &&
-			height == other.height;
-	}
+	bool operator==(const Rectangle& other) const = default;
 
-	bool operator!=(const Rectangle& other) const
-	{
-		return !(*this == other);
-	}
+	bool operator!=(const Rectangle& other) const = default;
 };
 
 /*! Display mode structure. */

--- a/code/Render/Vrfy/RenderViewVrfy.cpp
+++ b/code/Render/Vrfy/RenderViewVrfy.cpp
@@ -134,6 +134,13 @@ void RenderViewVrfy::setViewport(const Viewport& viewport)
 	m_renderView->setViewport(viewport);
 }
 
+void RenderViewVrfy::setScissor(const Rectangle& scissor)
+{
+	T_CAPTURE_TRACE(L"setScissor");
+	T_CAPTURE_ASSERT(m_insideFrame, L"Cannot set scissor outside of frame.");
+	m_renderView->setScissor(scissor);
+}
+
 SystemWindow RenderViewVrfy::getSystemWindow()
 {
 	T_CAPTURE_TRACE(L"getSystemWindow");

--- a/code/Render/Vrfy/RenderViewVrfy.h
+++ b/code/Render/Vrfy/RenderViewVrfy.h
@@ -72,6 +72,8 @@ public:
 	virtual bool setGamma(float gamma) override final;
 
 	virtual void setViewport(const Viewport& viewport) override final;
+    
+	virtual void setScissor(const Rectangle& scissor) override final;
 
 	virtual SystemWindow getSystemWindow() override final;
 

--- a/code/Render/Vulkan/Android/ApiLoader.cpp
+++ b/code/Render/Vulkan/Android/ApiLoader.cpp
@@ -97,6 +97,7 @@ T_DEFINE_VK(vkQueueWaitIdle);
 T_DEFINE_VK(vkCmdCopyBufferToImage);
 T_DEFINE_VK(vkEnumerateDeviceExtensionProperties);
 T_DEFINE_VK(vkCmdSetViewport);
+T_DEFINE_VK(vkCmdSetScissor);
 T_DEFINE_VK(vkFreeMemory);
 T_DEFINE_VK(vkDestroyBuffer);
 T_DEFINE_VK(vkCmdCopyImage);
@@ -231,6 +232,7 @@ bool initializeVulkanApi()
 	T_RESOLVE_VK(vkCmdCopyBufferToImage);
 	T_RESOLVE_VK(vkEnumerateDeviceExtensionProperties);
 	T_RESOLVE_VK(vkCmdSetViewport);
+	T_RESOLVE_VK(vkCmdSetScissor);
 	T_RESOLVE_VK(vkFreeMemory);
 	T_RESOLVE_VK(vkDestroyBuffer);
 	T_RESOLVE_VK(vkCmdCopyImage);

--- a/code/Render/Vulkan/Android/ApiLoader.h
+++ b/code/Render/Vulkan/Android/ApiLoader.h
@@ -81,6 +81,7 @@ extern PFN_vkQueueWaitIdle vkQueueWaitIdle;
 extern PFN_vkCmdCopyBufferToImage vkCmdCopyBufferToImage;
 extern PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;
 extern PFN_vkCmdSetViewport vkCmdSetViewport;
+extern PFN_vkCmdSetScissor vkCmdSetScissor;
 extern PFN_vkFreeMemory vkFreeMemory;
 extern PFN_vkDestroyBuffer vkDestroyBuffer;
 extern PFN_vkCmdCopyImage vkCmdCopyImage;

--- a/code/Render/Vulkan/Linux/ApiLoader.cpp
+++ b/code/Render/Vulkan/Linux/ApiLoader.cpp
@@ -98,6 +98,7 @@ T_DEFINE_VK(vkQueueWaitIdle);
 T_DEFINE_VK(vkCmdCopyBufferToImage);
 T_DEFINE_VK(vkEnumerateDeviceExtensionProperties);
 T_DEFINE_VK(vkCmdSetViewport);
+T_DEFINE_VK(vkCmdSetScissor);
 T_DEFINE_VK(vkFreeMemory);
 T_DEFINE_VK(vkDestroyBuffer);
 T_DEFINE_VK(vkCmdCopyImage);
@@ -245,6 +246,7 @@ bool initializeVulkanApi()
 	T_RESOLVE_VK(vkCmdCopyBufferToImage);
 	T_RESOLVE_VK(vkEnumerateDeviceExtensionProperties);
 	T_RESOLVE_VK(vkCmdSetViewport);
+	T_RESOLVE_VK(vkCmdSetScissor);
 	T_RESOLVE_VK(vkFreeMemory);
 	T_RESOLVE_VK(vkDestroyBuffer);
 	T_RESOLVE_VK(vkCmdCopyImage);

--- a/code/Render/Vulkan/Linux/ApiLoader.h
+++ b/code/Render/Vulkan/Linux/ApiLoader.h
@@ -82,6 +82,7 @@ extern PFN_vkQueueWaitIdle vkQueueWaitIdle;
 extern PFN_vkCmdCopyBufferToImage vkCmdCopyBufferToImage;
 extern PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;
 extern PFN_vkCmdSetViewport vkCmdSetViewport;
+extern PFN_vkCmdSetScissor vkCmdSetScissor;
 extern PFN_vkFreeMemory vkFreeMemory;
 extern PFN_vkDestroyBuffer vkDestroyBuffer;
 extern PFN_vkCmdCopyImage vkCmdCopyImage;

--- a/code/Render/Vulkan/RenderViewVk.cpp
+++ b/code/Render/Vulkan/RenderViewVk.cpp
@@ -527,10 +527,10 @@ void RenderViewVk::setViewport(const Viewport& viewport)
 
 void RenderViewVk::setScissor(const Rectangle& scissor)
 {
-	T_ASSERT(scissorRect.left >= 0);
-	T_ASSERT(scissorRect.top >= 0);
-	T_ASSERT(scissorRect.width >= 0);
-	T_ASSERT(scissorRect.height >= 0);
+	T_ASSERT(scissor.left >= 0);
+	T_ASSERT(scissor.top >= 0);
+	T_ASSERT(scissor.width >= 0);
+	T_ASSERT(scissor.height >= 0);
 
 	const auto& frame = m_frames[m_currentImageIndex];
 	VkRect2D vkScissor =

--- a/code/Render/Vulkan/RenderViewVk.cpp
+++ b/code/Render/Vulkan/RenderViewVk.cpp
@@ -533,9 +533,19 @@ void RenderViewVk::setScissor(const Rectangle& scissor)
 	T_ASSERT(scissorRect.height >= 0);
 
 	const auto& frame = m_frames[m_currentImageIndex];
-	VkRect2D vkScissor = {};
-	vkScissor.offset = VkOffset2D { scissor.left, scissor.top };
-	vkScissor.extent = VkExtent2D { static_cast<uint32_t>(scissor.width), static_cast<uint32_t>(scissor.height) };
+	VkRect2D vkScissor =
+	{
+		.offset = VkOffset2D
+		{ 
+			.x = scissor.left, 
+			.y = scissor.top 
+		},
+		.extent = VkExtent2D
+		{ 
+			.width = (uint32_t)scissor.width,
+			.height = (uint32_t)scissor.height
+		}
+	};
 	vkCmdSetScissor(*frame.graphicsCommandBuffer, 0, 1, &vkScissor);
 }
 
@@ -802,9 +812,19 @@ bool RenderViewVk::beginPass(IRenderTargetSet* renderTargetSet, const Clear* cle
 	vkCmdSetViewport(*frame.graphicsCommandBuffer, 0, 1, &vp);
 
 	// Set scissor
-	VkRect2D vkScissor = {};
-	vkScissor.offset = VkOffset2D{ 0, 0 };
-	vkScissor.extent = VkExtent2D{ (uint32_t)m_targetSet->getWidth(), (uint32_t)m_targetSet->getHeight() };
+	VkRect2D vkScissor = 
+	{
+		.offset = VkOffset2D 
+		{
+			.x = 0,
+			.y = 0
+		},
+		.extent = VkExtent2D 
+		{
+			.width = (uint32_t)m_targetSet->getWidth(),
+			.height = (uint32_t)m_targetSet->getHeight()
+		}
+	};
 	vkCmdSetScissor(*frame.graphicsCommandBuffer, 0, 1, &vkScissor);
 
 	m_passCount++;
@@ -920,9 +940,19 @@ bool RenderViewVk::beginPass(IRenderTargetSet* renderTargetSet, int32_t renderTa
 	vkCmdSetViewport(*frame.graphicsCommandBuffer, 0, 1, &vp);
 
 	// Set scissor
-	VkRect2D vkScissor = {};
-	vkScissor.offset = VkOffset2D{ 0, 0 };
-	vkScissor.extent = VkExtent2D{ (uint32_t)m_targetSet->getWidth(), (uint32_t)m_targetSet->getHeight() };
+	VkRect2D vkScissor =
+	{
+		.offset = VkOffset2D
+		{ 
+			.x = 0, 
+			.y = 0 
+		},
+		.extent = VkExtent2D
+		{ 
+			.width = (uint32_t)m_targetSet->getWidth(), 
+			.height = (uint32_t)m_targetSet->getHeight() 
+		}
+	};
 	vkCmdSetScissor(*frame.graphicsCommandBuffer, 0, 1, &vkScissor);
 
 	m_passCount++;

--- a/code/Render/Vulkan/RenderViewVk.h
+++ b/code/Render/Vulkan/RenderViewVk.h
@@ -86,6 +86,8 @@ public:
 	virtual bool setGamma(float gamma) override final;
 
 	virtual void setViewport(const Viewport& viewport) override final;
+    
+	virtual void setScissor(const Rectangle& scissor) override final;
 
 	virtual SystemWindow getSystemWindow() override final;
 

--- a/code/Render/Vulkan/Win32/ApiLoader.cpp
+++ b/code/Render/Vulkan/Win32/ApiLoader.cpp
@@ -97,6 +97,7 @@ T_DEFINE_VK(vkQueueWaitIdle);
 T_DEFINE_VK(vkCmdCopyBufferToImage);
 T_DEFINE_VK(vkEnumerateDeviceExtensionProperties);
 T_DEFINE_VK(vkCmdSetViewport);
+T_DEFINE_VK(vkCmdSetScissor);
 T_DEFINE_VK(vkFreeMemory);
 T_DEFINE_VK(vkDestroyBuffer);
 T_DEFINE_VK(vkCmdCopyImage);
@@ -244,6 +245,7 @@ bool initializeVulkanApi()
 	T_RESOLVE_VK(vkCmdCopyBufferToImage);
 	T_RESOLVE_VK(vkEnumerateDeviceExtensionProperties);
 	T_RESOLVE_VK(vkCmdSetViewport);
+	T_RESOLVE_VK(vkCmdSetScissor);
 	T_RESOLVE_VK(vkFreeMemory);
 	T_RESOLVE_VK(vkDestroyBuffer);
 	T_RESOLVE_VK(vkCmdCopyImage);

--- a/code/Render/Vulkan/Win32/ApiLoader.h
+++ b/code/Render/Vulkan/Win32/ApiLoader.h
@@ -82,6 +82,7 @@ extern PFN_vkQueueWaitIdle vkQueueWaitIdle;
 extern PFN_vkCmdCopyBufferToImage vkCmdCopyBufferToImage;
 extern PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;
 extern PFN_vkCmdSetViewport vkCmdSetViewport;
+extern PFN_vkCmdSetScissor vkCmdSetScissor;
 extern PFN_vkFreeMemory vkFreeMemory;
 extern PFN_vkDestroyBuffer vkDestroyBuffer;
 extern PFN_vkCmdCopyImage vkCmdCopyImage;

--- a/code/Render/Vulkan/macOS/ApiLoader.cpp
+++ b/code/Render/Vulkan/macOS/ApiLoader.cpp
@@ -97,6 +97,7 @@ T_DEFINE_VK(vkQueueWaitIdle);
 T_DEFINE_VK(vkCmdCopyBufferToImage);
 T_DEFINE_VK(vkEnumerateDeviceExtensionProperties);
 T_DEFINE_VK(vkCmdSetViewport);
+T_DEFINE_VK(vkCmdSetScissor);
 T_DEFINE_VK(vkFreeMemory);
 T_DEFINE_VK(vkDestroyBuffer);
 T_DEFINE_VK(vkCmdCopyImage);
@@ -232,6 +233,7 @@ bool initializeVulkanApi()
 	T_RESOLVE_VK(vkCmdCopyBufferToImage);
 	T_RESOLVE_VK(vkEnumerateDeviceExtensionProperties);
 	T_RESOLVE_VK(vkCmdSetViewport);
+	T_RESOLVE_VK(vkCmdSetScissor);
 	T_RESOLVE_VK(vkFreeMemory);
 	T_RESOLVE_VK(vkDestroyBuffer);
 	T_RESOLVE_VK(vkCmdCopyImage);

--- a/code/Render/Vulkan/macOS/ApiLoader.h
+++ b/code/Render/Vulkan/macOS/ApiLoader.h
@@ -81,6 +81,7 @@ extern PFN_vkQueueWaitIdle vkQueueWaitIdle;
 extern PFN_vkCmdCopyBufferToImage vkCmdCopyBufferToImage;
 extern PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;
 extern PFN_vkCmdSetViewport vkCmdSetViewport;
+extern PFN_vkCmdSetScissor vkCmdSetScissor;
 extern PFN_vkFreeMemory vkFreeMemory;
 extern PFN_vkDestroyBuffer vkDestroyBuffer;
 extern PFN_vkCmdCopyImage vkCmdCopyImage;

--- a/code/World/Shared/WorldRendererShared.cpp
+++ b/code/World/Shared/WorldRendererShared.cpp
@@ -520,17 +520,7 @@ void WorldRendererShared::setupLightPass(
 							0.0f,
 							1.0f
 						);
-						renderContext->draw(svrb);
-
-						// Set scissor.
-						auto ssrb = renderContext->alloc< render::SetScissorRenderBlock >();
-						ssrb->scissor = render::Rectangle(
-							svrb->viewport.left,
-							svrb->viewport.top,
-							svrb->viewport.width,
-							svrb->viewport.height
-						);
-						renderContext->draw(ssrb);
+						renderContext->draw(svrb);	
 
 						// Render entities into shadow map.
 						auto sharedParams = renderContext->alloc< render::ProgramParameters >();
@@ -676,17 +666,6 @@ void WorldRendererShared::setupLightPass(
 						1.0f
 					);
 					renderContext->draw(svrb);	
-
-					// Set scissor.
-					auto ssrb = renderContext->alloc< render::SetScissorRenderBlock >();
-					ssrb->scissor = render::Rectangle(
-						svrb->viewport.left,
-						svrb->viewport.top,
-						svrb->viewport.width,
-						svrb->viewport.height
-					);
-					renderContext->draw(ssrb);
-
 
 					// Render entities into shadow map.
 					auto sharedParams = renderContext->alloc< render::ProgramParameters >();

--- a/code/World/Shared/WorldRendererShared.cpp
+++ b/code/World/Shared/WorldRendererShared.cpp
@@ -520,7 +520,17 @@ void WorldRendererShared::setupLightPass(
 							0.0f,
 							1.0f
 						);
-						renderContext->draw(svrb);	
+						renderContext->draw(svrb);
+
+						// Set scissor.
+						auto ssrb = renderContext->alloc< render::SetScissorRenderBlock >();
+						ssrb->scissor = render::Rectangle(
+							svrb->viewport.left,
+							svrb->viewport.top,
+							svrb->viewport.width,
+							svrb->viewport.height
+						);
+						renderContext->draw(ssrb);
 
 						// Render entities into shadow map.
 						auto sharedParams = renderContext->alloc< render::ProgramParameters >();
@@ -666,6 +676,17 @@ void WorldRendererShared::setupLightPass(
 						1.0f
 					);
 					renderContext->draw(svrb);	
+
+					// Set scissor.
+					auto ssrb = renderContext->alloc< render::SetScissorRenderBlock >();
+					ssrb->scissor = render::Rectangle(
+						svrb->viewport.left,
+						svrb->viewport.top,
+						svrb->viewport.width,
+						svrb->viewport.height
+					);
+					renderContext->draw(ssrb);
+
 
 					// Render entities into shadow map.
 					auto sharedParams = renderContext->alloc< render::ProgramParameters >();


### PR DESCRIPTION
Add scissor to dynamic states in vulkan backend.

Set  initial scissor in begin pass

Set scissor in WorldRendererShared::setupLightPass to match viewport