### PR TITLE
Traktor: RTTI and scripting improvements

### DIFF
--- a/code/Core/Class/Boxes/BoxedAlignedVector.h
+++ b/code/Core/Class/Boxes/BoxedAlignedVector.h
@@ -11,6 +11,7 @@
 #include "Core/Containers/AlignedVector.h"
 #include "Core/Class/Any.h"
 #include "Core/Class/Boxed.h"
+#include "Core/Class/Boxes/BoxedTypeHelper.h"
 #include "Core/Class/CastAny.h"
 
 // import/export mechanism.
@@ -92,7 +93,7 @@ template < typename InnerType >
 struct CastAny < AlignedVector< InnerType >, false >
 {
 	static std::wstring typeName() {
-		return L"traktor.AlignedVector< InnerType >";
+		return str(L"traktor.AlignedVector< %ls >", BoxedInnerTypeName< InnerType >::get().c_str());
 	}
 	static bool accept(const Any& value) {
 		return value.isObject() && is_a< BoxedAlignedVector >(value.getObjectUnsafe());
@@ -112,7 +113,7 @@ template < typename InnerType >
 struct CastAny < const AlignedVector< InnerType >&, false >
 {
 	static std::wstring typeName() {
-		return L"const traktor.AlignedVector< InnerType >&";
+		return str(L"const traktor.AlignedVector< %ls >&", BoxedInnerTypeName< InnerType >::get().c_str());
 	}
 	static bool accept(const Any& value) {
 		return value.isObject() && is_a< BoxedAlignedVector >(value.getObjectUnsafe());

--- a/code/Core/Class/Boxes/BoxedRange.h
+++ b/code/Core/Class/Boxes/BoxedRange.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Core/Class/Boxed.h"
+#include "Core/Class/Boxes/BoxedTypeHelper.h"
 #include "Core/Class/CastAny.h"
 #include "Core/Math/Range.h"
 
@@ -71,7 +72,7 @@ template < typename InnerType >
 struct CastAny< Range< InnerType >, false >
 {
 	static std::wstring typeName() {
-		return L"traktor.Range< InnerType >";
+		return str(L"traktor.Range< %ls >", BoxedInnerTypeName< InnerType >::get().c_str());
 	}
 	static bool accept(const Any& value) {
 		return value.isObject() && is_a< BoxedRange >(value.getObjectUnsafe());
@@ -91,7 +92,7 @@ template < typename InnerType >
 struct CastAny< const Range< InnerType >&, false >
 {
 	static std::wstring typeName() {
-		return L"const traktor.Range< InnerType >&";
+		return str(L"const traktor.Range< %ls >&", BoxedInnerTypeName< InnerType >::get().c_str());
 	}
 	static bool accept(const Any& value) {
 		return value.isObject() && is_a< BoxedRange >(value.getObjectUnsafe());

--- a/code/Core/Class/Boxes/BoxedStdVector.h
+++ b/code/Core/Class/Boxes/BoxedStdVector.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include "Core/Class/Boxed.h"
+#include "Core/Class/Boxes/BoxedTypeHelper.h"
 #include "Core/Class/CastAny.h"
 
 // import/export mechanism.
@@ -91,7 +92,7 @@ template < typename InnerType >
 struct CastAny < std::vector< InnerType >, false >
 {
 	static std::wstring typeName() {
-		return L"traktor.StdVector< T >";
+		return str(L"traktor.StdVector< %ls >", BoxedInnerTypeName< InnerType >::get().c_str());
 	}
 	static bool accept(const Any& value) {
 		return value.isObject() && is_a< BoxedStdVector >(value.getObjectUnsafe());
@@ -111,7 +112,7 @@ template < typename InnerType >
 struct CastAny < const std::vector< InnerType >&, false >
 {
 	static std::wstring typeName() {
-		return L"const traktor.StdVector< T >&";
+		return str(L"const traktor.StdVector< %ls >&", BoxedInnerTypeName< InnerType >::get().c_str());
 	}
 	static bool accept(const Any& value) {
 		return value.isObject() && is_a< BoxedStdVector >(value.getObjectUnsafe());

--- a/code/Core/Class/Boxes/BoxedTypeHelper.h
+++ b/code/Core/Class/Boxes/BoxedTypeHelper.h
@@ -1,0 +1,57 @@
+/*
+ * TRAKTOR
+ * Copyright (c) 2022 Anders Pistol.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+
+#include <string>
+#include "Core/Rtti/ITypedObject.h"
+
+namespace traktor
+{
+
+// Helper to get type name for boxed inner types (handles both RTTI and primitive types)
+template < typename T, bool HasRtti = std::is_base_of< ITypedObject, T >::value >
+struct BoxedInnerTypeName
+{
+	static std::wstring get() { return type_name< T >(); }
+};
+
+// Forward declarations for math types
+class Matrix33;
+class Matrix44;
+class Quaternion;
+class Vector2;
+class Vector4;
+class Color4f;
+class Color4ub;
+class Scalar;
+class Any;
+
+// Specializations for primitive types that don't have RTTI
+template <> struct BoxedInnerTypeName< float, false > { static std::wstring get() { return L"float"; } };
+template <> struct BoxedInnerTypeName< double, false > { static std::wstring get() { return L"double"; } };
+template <> struct BoxedInnerTypeName< int32_t, false > { static std::wstring get() { return L"int32"; } };
+template <> struct BoxedInnerTypeName< int64_t, false > { static std::wstring get() { return L"int64"; } };
+template <> struct BoxedInnerTypeName< uint32_t, false > { static std::wstring get() { return L"uint32"; } };
+template <> struct BoxedInnerTypeName< uint64_t, false > { static std::wstring get() { return L"uint64"; } };
+template <> struct BoxedInnerTypeName< bool, false > { static std::wstring get() { return L"bool"; } };
+template <> struct BoxedInnerTypeName< std::wstring, false > { static std::wstring get() { return L"std::wstring"; } };
+template <> struct BoxedInnerTypeName< std::string, false > { static std::wstring get() { return L"std::string"; } };
+
+// Specializations for math types that don't have RTTI
+template <> struct BoxedInnerTypeName< Matrix33, false > { static std::wstring get() { return L"traktor.Matrix33"; } };
+template <> struct BoxedInnerTypeName< Matrix44, false > { static std::wstring get() { return L"traktor.Matrix44"; } };
+template <> struct BoxedInnerTypeName< Quaternion, false > { static std::wstring get() { return L"traktor.Quaternion"; } };
+template <> struct BoxedInnerTypeName< Vector2, false > { static std::wstring get() { return L"traktor.Vector2"; } };
+template <> struct BoxedInnerTypeName< Vector4, false > { static std::wstring get() { return L"traktor.Vector4"; } };
+template <> struct BoxedInnerTypeName< Color4f, false > { static std::wstring get() { return L"traktor.Color4f"; } };
+template <> struct BoxedInnerTypeName< Color4ub, false > { static std::wstring get() { return L"traktor.Color4ub"; } };
+template <> struct BoxedInnerTypeName< Scalar, false > { static std::wstring get() { return L"traktor.Scalar"; } };
+template <> struct BoxedInnerTypeName< Any, false > { static std::wstring get() { return L"traktor.Any"; } };
+
+}

--- a/code/Heightfield/HeightfieldClassFactory.cpp
+++ b/code/Heightfield/HeightfieldClassFactory.cpp
@@ -1,0 +1,39 @@
+/*
+ * TRAKTOR
+ * Copyright (c) 2022 Anders Pistol.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include "Heightfield/HeightfieldClassFactory.h"
+
+#include "Core/Class/AutoRuntimeClass.h"
+#include "Core/Class/Boxes/BoxedVector4.h"
+#include "Core/Class/IRuntimeClassRegistrar.h"
+#include "Heightfield/Heightfield.h"
+
+namespace traktor::hf
+{
+namespace
+{
+
+Vector4 Heightfield_gridToWorld_Vector4(Heightfield* self, float gridX, float gridZ)
+{
+	return self->gridToWorld(gridX, gridZ);
+}
+
+}
+
+T_IMPLEMENT_RTTI_FACTORY_CLASS(L"traktor.hf.HeightfieldClassFactory", 0, HeightfieldClassFactory, IRuntimeClassFactory)
+
+void HeightfieldClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
+{
+	auto classHeightfield = new AutoRuntimeClass< Heightfield >();
+	classHeightfield->addConstructor< int32_t, const Vector4& >();
+	classHeightfield->addProperty("size", &Heightfield::getSize);
+	classHeightfield->addProperty("worldExtent", &Heightfield::getWorldExtent);
+	registrar->registerClass(classHeightfield);
+}
+
+}

--- a/code/Heightfield/HeightfieldClassFactory.h
+++ b/code/Heightfield/HeightfieldClassFactory.h
@@ -1,0 +1,32 @@
+/*
+ * TRAKTOR
+ * Copyright (c) 2022 Anders Pistol.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+
+#include "Core/Class/IRuntimeClassFactory.h"
+
+// import/export mechanism.
+#undef T_DLLCLASS
+#if defined(T_HEIGHTFIELD_EXPORT)
+#	define T_DLLCLASS T_DLLEXPORT
+#else
+#	define T_DLLCLASS T_DLLIMPORT
+#endif
+
+namespace traktor::hf
+{
+
+class T_DLLCLASS HeightfieldClassFactory : public IRuntimeClassFactory
+{
+	T_RTTI_CLASS;
+
+public:
+	virtual void createClasses(IRuntimeClassRegistrar* registrar) const override final;
+};
+
+}

--- a/code/Heightfield/Module.cpp
+++ b/code/Heightfield/Module.cpp
@@ -9,14 +9,19 @@
 #include "Core/Rtti/TypeInfo.h"
 
 #if defined(T_STATIC)
+#	include "Heightfield/HeightfieldClassFactory.h"
+#endif
 
 namespace traktor::hf
 {
 
+#if defined(T_STATIC)
+
 extern "C" void __module__Traktor_Heightfield()
 {
-}
-
+	T_FORCE_LINK_REF(HeightfieldClassFactory);
 }
 
 #endif
+
+}

--- a/code/Input/InputClassFactory.cpp
+++ b/code/Input/InputClassFactory.cpp
@@ -13,6 +13,8 @@
 #include "Input/IInputDriver.h"
 #include "Input/InputClassFactory.h"
 #include "Input/InputSystem.h"
+#include "Input/RumbleEffect.h"
+#include "Input/RumbleEffectPlayer.h"
 #include "Input/Binding/EnumKeys.h"
 #include "Input/Binding/IInputSource.h"
 #include "Input/Binding/InputMapping.h"
@@ -227,6 +229,17 @@ void InputClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
 	classInputState->addMethod("isReleased", &InputState::isReleased);
 	classInputState->addMethod("hasChanged", &InputState::hasChanged);
 	registrar->registerClass(classInputState);
+
+	auto classRumbleEffect = new AutoRuntimeClass< RumbleEffect >();
+	classRumbleEffect->addMethod("getDuration", &RumbleEffect::getDuration);
+	registrar->registerClass(classRumbleEffect);
+
+	auto classRumbleEffectPlayer = new AutoRuntimeClass< RumbleEffectPlayer >();
+	classRumbleEffectPlayer->addMethod("play", &RumbleEffectPlayer::play);
+	classRumbleEffectPlayer->addMethod("stop", &RumbleEffectPlayer::stop);
+	classRumbleEffectPlayer->addMethod("stopAll", &RumbleEffectPlayer::stopAll);
+	classRumbleEffectPlayer->addMethod("update", &RumbleEffectPlayer::update);
+	registrar->registerClass(classRumbleEffectPlayer);
 }
 
 }

--- a/code/Physics/PhysicsClassFactory.cpp
+++ b/code/Physics/PhysicsClassFactory.cpp
@@ -282,6 +282,9 @@ void PhysicsClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
 	classQueryResult->addProperty("material", &QueryResultWrapper::material);
 	registrar->registerClass(classQueryResult);
 
+	auto classBoxedBodyState = new AutoRuntimeClass< BoxedBodyState >();
+	registrar->registerClass(classBoxedBodyState);
+
 	auto classPhysicsManager = new AutoRuntimeClass< PhysicsManager >();
 	classPhysicsManager->addProperty("gravity", &PhysicsManager::setGravity, &PhysicsManager::getGravity);
 	classPhysicsManager->addProperty("bodies", &PhysicsManager::getBodies);

--- a/code/Render/RenderClassFactory.cpp
+++ b/code/Render/RenderClassFactory.cpp
@@ -216,6 +216,9 @@ void RenderClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
 	classBuffer->addMethod("unlock", &Buffer::unlock);
 	registrar->registerClass(classBuffer);
 
+	auto classIBufferView = new AutoRuntimeClass< IBufferView >();
+	registrar->registerClass(classIBufferView);
+
 	auto classITexture = new AutoRuntimeClass< ITexture >();
 	classITexture->addMethod("lock", &ITexture_lock);
 	classITexture->addMethod("unlock", &ITexture::unlock);

--- a/code/Runtime/Impl/ScriptServer.cpp
+++ b/code/Runtime/Impl/ScriptServer.cpp
@@ -69,6 +69,10 @@ bool ScriptServer::create(
 	}
 	registrar.registerClassesInOrder(m_scriptManager);
 
+	// Complete registration of all classes (register members, methods, properties, etc.)
+	// This is needed for script backends that require two-phase registration (e.g., AngelScript).
+	m_scriptManager->completeRegistration();
+
 	// Create and attach debugger.
 	if (debugger)
 	{

--- a/code/Script/Editor/ScriptEditorPlugin.cpp
+++ b/code/Script/Editor/ScriptEditorPlugin.cpp
@@ -45,6 +45,10 @@ bool ScriptEditorPlugin::create(editor::IEditor* editor, ui::Widget* parent, edi
 		}
 		registrar.registerClassesInOrder(m_scriptManager);
 
+		// Complete registration of all classes (register members, methods, properties, etc.)
+		// This is needed for script backends that require two-phase registration (e.g., AngelScript).
+		m_scriptManager->completeRegistration();
+
 		// Expose script manager to other editors.
 		m_editor->getObjectStore()->set(m_scriptManager);
 	}

--- a/code/Script/IScriptManager.h
+++ b/code/Script/IScriptManager.h
@@ -65,6 +65,16 @@ public:
 	/*! Destroy script manager. */
 	virtual void destroy() = 0;
 
+	/*! Complete registration of all classes.
+	 *
+	 * This is called after all classes have been registered via registerClass().
+	 * Some script backends (like AngelScript) require two-phase registration where
+	 * types are registered first, then members are registered in a second phase.
+	 * This allows handling forward references and circular dependencies.
+	 * For backends that don't need this (like Lua), this can be a no-op.
+	 */
+	virtual void completeRegistration() = 0;
+
 	/*! Create script context.
 	 *
 	 * \param strict Strict global variable declaration required.

--- a/code/Script/Lua/ScriptManagerLua.cpp
+++ b/code/Script/Lua/ScriptManagerLua.cpp
@@ -418,6 +418,11 @@ void ScriptManagerLua::registerClass(IRuntimeClass* runtimeClass)
 	}
 }
 
+void ScriptManagerLua::completeRegistration()
+{
+	// Lua doesn't need two-phase registration; everything is done in registerClass().
+}
+
 Ref< IScriptContext > ScriptManagerLua::createContext(bool strict)
 {
 #if defined(T_SCRIPT_LUA_USE_MT_LOCK)

--- a/code/Script/Lua/ScriptManagerLua.h
+++ b/code/Script/Lua/ScriptManagerLua.h
@@ -59,6 +59,8 @@ public:
 
 	virtual void registerClass(IRuntimeClass* runtimeClass) override final;
 
+	virtual void completeRegistration() override final;
+
 	virtual Ref< IScriptContext > createContext(bool strict) override final;
 
 	virtual Ref< IScriptDebugger > createDebugger() override final;

--- a/code/Spark/ClassFactory.cpp
+++ b/code/Spark/ClassFactory.cpp
@@ -442,6 +442,10 @@ void ClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
 	classFont->addMethod("lookupIndex", &Font::lookupIndex);
 	registrar->registerClass(classFont);
 
+	// Frame
+	auto classFrame = new AutoRuntimeClass< Frame >();
+	registrar->registerClass(classFrame);
+
 	// ICharacterFactory
 	auto classICharacterFactory = new AutoRuntimeClass< ICharacterFactory >();
 	registrar->registerClass(classICharacterFactory);
@@ -535,6 +539,10 @@ void ClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
 	classMoviePlayer->addMethod("postMouseUp", &MoviePlayer::postMouseUp);
 	classMoviePlayer->addMethod("postMouseMove", &MoviePlayer::postMouseMove);
 	registrar->registerClass(classMoviePlayer);
+
+	// MovieResult
+	auto classMovieResult = new AutoRuntimeClass< MovieResult >();
+	registrar->registerClass(classMovieResult);
 
 	// Optimizer
 	auto classOptimizer = new AutoRuntimeClass< Optimizer >();

--- a/code/Terrain/TerrainClassFactory.cpp
+++ b/code/Terrain/TerrainClassFactory.cpp
@@ -46,6 +46,9 @@ void TerrainClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
 	classTerrain->addProperty("cutMap", &Terrain::getCutMap);
 	registrar->registerClass(classTerrain);
 
+	auto classTerrainSurfaceCache = new AutoRuntimeClass< TerrainSurfaceCache >();
+	registrar->registerClass(classTerrainSurfaceCache);
+
 	auto classTerrainComponent = new AutoRuntimeClass< TerrainComponent >();
 	classTerrainComponent->addProperty("terrain", &TerrainComponent::getTerrain);
 	classTerrainComponent->addProperty("patchCount", &TerrainComponent::getPatchCount);

--- a/code/World/WorldClassFactory.cpp
+++ b/code/World/WorldClassFactory.cpp
@@ -24,6 +24,7 @@
 #include "World/IWorldComponent.h"
 #include "World/IWorldRenderer.h"
 #include "World/WorldClassFactory.h"
+#include "World/WorldEntityRenderers.h"
 #include "World/Entity/CameraComponent.h"
 #include "World/Entity/CameraComponentData.h"
 #include "World/Entity.h"
@@ -225,6 +226,9 @@ void WorldClassFactory::createClasses(IRuntimeClassRegistrar* registrar) const
 
 	auto classIEntityRenderer = new AutoRuntimeClass< IEntityRenderer >();
 	registrar->registerClass(classIEntityRenderer);
+
+	auto classWorldEntityRenderers = new AutoRuntimeClass< WorldEntityRenderers >();
+	registrar->registerClass(classWorldEntityRenderers);
 
 	auto classEntityData = new AutoRuntimeClass< EntityData >();
 	classEntityData->addConstructor();


### PR DESCRIPTION
I am in the process of adding angelscript bindings in my fork of Traktor.
I've made some changes to Traktor to support my effort so far.
I've extracted these changes for this PR, to gauge if you're interested in having these changes in Traktor.
The changes are mostly adding some more types to the class registry, as they are referenced by some other registered classes/methods.

I've also added a method to the script manager interface, intended to be called after all classes are added to the script manager.
Angelscript works in a way where any type referenced when registering a symbol must have already been registered.
I convenient way to do this is to register all types first, then register all the members on the types after all types are registered.

I've also added a Boxed type helper to give the boxed container template parameters proper names instead of just InnerType or T.