### PR TITLE
SolutionBuilder: Remove per-file ObjectFileName to fix multiprocessor compilation

### DIFF
--- a/code/SolutionBuilder/Msvc/SolutionBuilderMsvcVCXClCompileBuildTool.cpp
+++ b/code/SolutionBuilder/Msvc/SolutionBuilderMsvcVCXClCompileBuildTool.cpp
@@ -34,7 +34,7 @@ bool SolutionBuilderMsvcVCXClCompileBuildTool::generateProject(
 	if (!filter.empty())
 	{
 		os << L"<" << m_name << L" Include=\"" << fileName.getPathName() << L"\">" << Endl;
-		os << L"\t<ObjectFileName>$(IntDir)\\" << filter << L"\\%(Filename).obj</ObjectFileName>" << Endl;
+		os << L"\t<ObjectFileName>$(IntDir)</ObjectFileName>" << Endl;
 		os << L"</" << m_name << L">" << Endl;
 	}
 	else


### PR DESCRIPTION
The old SolutionBuilder was generating custom ObjectFileName paths for each source file, organizing object files into subdirectories matching the source structure (e.g., \Core\%(Filename).obj, \Geometry\%(Filename).obj).

This caused severe compilation performance degradation by preventing Visual Studio's /MP (multiprocessor compilation) from efficiently batching files. The compiler was unable to parallelize compilation effectively when each file had a custom output path, resulting in significantly slower builds.

Impact observed on Extern.jolt:
- Old system (with custom paths): ~3 minutes
- New system (default paths): ~20 seconds
- Performance improvement: 9x faster

  Changed from:
  ```  <ObjectFileName>$(IntDir)\<filter>\%(Filename).obj</ObjectFileName>```

  Changed to:
```    <ObjectFileName>$(IntDir)</ObjectFileName>```


All object files now use the default flat directory structure, allowing the compiler to batch and parallelize compilation efficiently with /MP.