### PR TITLE
Rename cut brush to hole brush in terrain editor

### DIFF
--- a/resources/runtime/editor/locale/english/Traktor.Terrain.Editor.dictionary
+++ b/resources/runtime/editor/locale/english/Traktor.Terrain.Editor.dictionary
@@ -7,7 +7,7 @@
     </item>
     <item>
       <first>TERRAIN_EDITOR_CUT_BRUSH</first>
-      <second>Cut brush</second>
+      <second>Hole brush</second>
     </item>
     <item>
       <first>TERRAIN_EDITOR_EDIT_TERRAIN</first>


### PR DESCRIPTION
The cut brush produces masked terrain holes, so it's probably better it be called the hole brush in the editor UI instead to avoid any ambiguity.