### PR TITLE
Solution Builder: Set default startup project to Traktor.Editor.App for all applicable Solutions

### DIFF
--- a/resources/build/TraktorLinux.xms
+++ b/resources/build/TraktorLinux.xms
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<object type="traktor.sb.Solution" version="5">
+<object type="traktor.sb.Solution" version="6">
 	<name>Traktor Linux</name>
 	<rootPath>$(TRAKTOR_HOME)/build/linux</rootPath>
 	<aggregateOutputPath>$(TRAKTOR_HOME)/bin/latest/linux</aggregateOutputPath>
@@ -20926,4 +20926,5 @@
 		</item>
 		<item ref="/object/projects/item[12]/dependencies/item[16]/project"/>
 	</projects>
+	<startupProject ref="/object/projects/item[12]"/>
 </object>

--- a/resources/build/TraktorOSX.xms
+++ b/resources/build/TraktorOSX.xms
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<object type="traktor.sb.Solution" version="5">
+<object type="traktor.sb.Solution" version="6">
 	<name>Traktor OSX</name>
 	<rootPath>$(TRAKTOR_HOME)/build/osx</rootPath>
 	<aggregateOutputPath>$(TRAKTOR_HOME)/bin/latest/osx</aggregateOutputPath>
@@ -17768,4 +17768,5 @@
 			</dependencies>
 		</item>
 	</projects>
+	<startupProject ref="/object/projects/item[12]"/>
 </object>

--- a/resources/build/TraktorRPi.xms
+++ b/resources/build/TraktorRPi.xms
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<object type="traktor.sb.Solution" version="5">
+<object type="traktor.sb.Solution" version="6">
 	<name>Traktor Raspberry Pi</name>
 	<rootPath>$(TRAKTOR_HOME)/build/rpi</rootPath>
 	<aggregateOutputPath>$(TRAKTOR_HOME)/bin/latest/rpi</aggregateOutputPath>
@@ -17795,4 +17795,5 @@
 			</dependencies>
 		</item>
 	</projects>
+	<startupProject ref="/object/projects/item[12]"/>
 </object>

--- a/resources/build/TraktorWin64.xms
+++ b/resources/build/TraktorWin64.xms
@@ -22046,5 +22046,5 @@
 			</dependencies>
 		</item>
 	</projects>
-	<startupProject/>
+	<startupProject ref="/object/projects/item[8]"/>
 </object>


### PR DESCRIPTION
Somewhere along the way, the startup projects got set to Traktor.Animation. This sets them back to Traktor.Editor.App so users need to do less work from a fresh clone.